### PR TITLE
feature: [AIC-128] - add terraform cd

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,5 +28,19 @@ jobs:
       - name: Terraform Init
         run: terraform -chdir=terraform init
 
+      - name: Terraform Import (if resources already exist)
+        run: |
+          terraform -chdir=terraform import -input=false -no-color \
+            module.service_account_chats-service.google_service_account.this \
+            projects/intricate-pad-455413-f7/serviceAccounts/chats-service@intricate-pad-455413-f7.iam.gserviceaccount.com || true
+
+          terraform -chdir=terraform import -input=false -no-color \
+            module.vpc_connector.google_vpc_access_connector.this \
+            projects/intricate-pad-455413-f7/locations/europe-west1/connectors/locaccm-vpc-connector || true
+
+          terraform -chdir=terraform import -input=false -no-color \
+            module.cloud_run_chats-service.google_cloud_run_service.service \
+            locations/europe-west1/namespaces/intricate-pad-455413-f7/services/chats-service || true
+
       - name: Terraform Apply
         run: terraform -chdir=terraform apply -auto-approve

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release chats-service
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Deploy to Google Cloud Run
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS_CD }}
+          project_id: intricate-pad-455413-f7
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.5.7
+
+      - name: Terraform Init
+        run: terraform -chdir=terraform init
+
+      - name: Terraform Apply
+        run: terraform -chdir=terraform apply -auto-approve

--- a/terraform/cloudRun.tf
+++ b/terraform/cloudRun.tf
@@ -11,6 +11,9 @@ module "cloud_run_chats-service" {
   env_variables = {
     NODE_ENV = "production"
   }
+  secrets = {
+    DATABASE_URL = "DATABASE_URL_PROD"
+  }
 }
 
 module "cloud_run_chats-service_invokers" {

--- a/terraform/cloudRun.tf
+++ b/terraform/cloudRun.tf
@@ -1,0 +1,25 @@
+module "cloud_run_chats-service" {
+  source                = "./modules/cloud_run"
+  project_id            = "intricate-pad-455413-f7"
+  region                = "europe-west1"
+  service_name          = "chats-service"
+  repository_id         = "locaccm-repo-docker"
+  service_account_email = module.service_account_chats-service.email
+  vpc_connector         = module.vpc_connector.id
+  public                = false
+
+  env_variables = {
+    NODE_ENV = "production"
+  }
+}
+
+module "cloud_run_chats-service_invokers" {
+  depends_on = [module.cloud_run_chats-service]
+  source        = "./modules/cloud_run_invoker"
+  region        = "europe-west1"
+  service_name  = "chats-service"
+  invokers = {
+    frontend            = "frontend-service@intricate-pad-455413-f7.iam.gserviceaccount.com"
+    authentification    = "auth-service@intricate-pad-455413-f7.iam.gserviceaccount.com"
+  }
+}

--- a/terraform/modules/cloud_run/main.tf
+++ b/terraform/modules/cloud_run/main.tf
@@ -1,0 +1,37 @@
+resource "google_cloud_run_service" "service" {
+  name     = var.service_name
+  location = var.region
+
+  template {
+    metadata {
+      annotations = {
+        "run.googleapis.com/vpc-access-connector" = var.vpc_connector
+        }
+    }
+
+    spec {
+      containers {
+        image = "europe-west1-docker.pkg.dev/${var.project_id}/${var.repository_id}/${var.service_name}:latest"
+
+        ports {
+          container_port = 3000
+        }
+
+        dynamic "env" {
+          for_each = var.env_variables
+          content {
+            name  = env.key
+            value = env.value
+          }
+        }
+      }
+
+      service_account_name = var.service_account_email
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+}

--- a/terraform/modules/cloud_run/main.tf
+++ b/terraform/modules/cloud_run/main.tf
@@ -24,6 +24,18 @@ resource "google_cloud_run_service" "service" {
             value = env.value
           }
         }
+        dynamic "env" {
+          for_each = var.secrets
+          content {
+            name = env.key
+            value_from {
+              secret_key_ref {
+                name = env.value
+                key  = "latest"
+              }
+            }
+          }
+        }
       }
 
       service_account_name = var.service_account_email

--- a/terraform/modules/cloud_run/outputs.tf
+++ b/terraform/modules/cloud_run/outputs.tf
@@ -1,0 +1,4 @@
+output "service_url" {
+  description = "URL of the deployed Cloud Run service"
+  value       = google_cloud_run_service.service.status[0].url
+}

--- a/terraform/modules/cloud_run/variables.tf
+++ b/terraform/modules/cloud_run/variables.tf
@@ -1,0 +1,41 @@
+variable "project_id" {
+  type        = string
+  description = "GCP project ID"
+}
+
+variable "region" {
+  type        = string
+  description = "GCP region"
+}
+
+variable "service_name" {
+  type        = string
+  description = "Name of the Cloud Run service"
+}
+
+variable "repository_id" {
+  type        = string
+  description = "Artifact Registry Docker repository ID"
+}
+
+variable "service_account_email" {
+  type        = string
+  description = "Email of the service account to run the Cloud Run service"
+}
+
+variable "vpc_connector" {
+  type        = string
+  description = "Fully qualified name of the VPC connector"
+}
+
+variable "public" {
+  type        = bool
+  default     = false
+  description = "Whether to make the Cloud Run service public"
+}
+
+variable "env_variables" {
+  type        = map(string)
+  default     = {}
+  description = "Environment variables to inject into the container"
+}

--- a/terraform/modules/cloud_run/variables.tf
+++ b/terraform/modules/cloud_run/variables.tf
@@ -39,3 +39,8 @@ variable "env_variables" {
   default     = {}
   description = "Environment variables to inject into the container"
 }
+
+variable "secrets" {
+  type    = map(string)
+  default = {}
+}

--- a/terraform/modules/cloud_run_invoker/main.tf
+++ b/terraform/modules/cloud_run_invoker/main.tf
@@ -1,0 +1,8 @@
+resource "google_cloud_run_service_iam_member" "invokers" {
+  for_each = var.invokers
+
+  location = var.region
+  service  = var.service_name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${each.value}"
+}

--- a/terraform/modules/cloud_run_invoker/outputs.tf
+++ b/terraform/modules/cloud_run_invoker/outputs.tf
@@ -1,0 +1,3 @@
+output "applied_invokers" {
+  value = [for sa in var.invokers : sa]
+}

--- a/terraform/modules/cloud_run_invoker/variables.tf
+++ b/terraform/modules/cloud_run_invoker/variables.tf
@@ -1,0 +1,14 @@
+variable "region" {
+  description = "Region of the Cloud Run service"
+  type        = string
+}
+
+variable "service_name" {
+  description = "Name of the Cloud Run service to grant access to"
+  type        = string
+}
+
+variable "invokers" {
+  description = "Map of invokers (caller_id => service_account_email)"
+  type        = map(string)
+}

--- a/terraform/modules/service_account/main.tf
+++ b/terraform/modules/service_account/main.tf
@@ -1,0 +1,12 @@
+resource "google_service_account" "this" {
+  account_id   = var.account_id
+  display_name = var.display_name
+}
+
+resource "google_project_iam_member" "roles" {
+  for_each = toset(var.roles)
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.this.email}"
+}

--- a/terraform/modules/service_account/outputs.tf
+++ b/terraform/modules/service_account/outputs.tf
@@ -1,0 +1,3 @@
+output "email" {
+  value = google_service_account.this.email
+}

--- a/terraform/modules/service_account/variables.tf
+++ b/terraform/modules/service_account/variables.tf
@@ -1,0 +1,19 @@
+variable "account_id" {
+  description = "ID of the service account (unique)"
+  type        = string
+}
+
+variable "display_name" {
+  description = "Display name of the service account"
+  type        = string
+}
+
+variable "project_id" {
+  description = "Project ID where the service account is created"
+  type        = string
+}
+
+variable "roles" {
+  description = "List of IAM roles to assign to this service account"
+  type        = list(string)
+}

--- a/terraform/modules/vpc_connector/main.tf
+++ b/terraform/modules/vpc_connector/main.tf
@@ -1,0 +1,9 @@
+resource "google_vpc_access_connector" "this" {
+  name           = var.name
+  region         = var.region
+  network        = var.network
+  ip_cidr_range  = var.ip_cidr_range
+
+  min_throughput = 200
+  max_throughput = 300
+}

--- a/terraform/modules/vpc_connector/outputs.tf
+++ b/terraform/modules/vpc_connector/outputs.tf
@@ -1,0 +1,11 @@
+output "id" {
+  value = google_vpc_access_connector.this.id
+}
+
+output "name" {
+  value = google_vpc_access_connector.this.name
+}
+
+output "self_link" {
+  value = google_vpc_access_connector.this.self_link
+}

--- a/terraform/modules/vpc_connector/variables.tf
+++ b/terraform/modules/vpc_connector/variables.tf
@@ -1,0 +1,20 @@
+
+variable "name" {
+  description = "Name of the VPC connector"
+  type        = string
+}
+
+variable "region" {
+  description = "Region of the VPC connector"
+  type        = string
+}
+
+variable "network" {
+  description = "The VPC network name"
+  type        = string
+}
+
+variable "ip_cidr_range" {
+  description = "CIDR range for VPC connector IPs"
+  type        = string
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,5 @@
+provider "google" {
+  project     = "intricate-pad-455413-f7"
+  region      = "europe-west1"
+  zone        = "europe-west1-d"
+}

--- a/terraform/serviceAccount.tf
+++ b/terraform/serviceAccount.tf
@@ -1,0 +1,9 @@
+module "service_account_chats-service" {
+  source       = "./modules/service_account"
+  account_id   = "chats-service"
+  display_name = "Chats Service Account"
+  project_id   = "intricate-pad-455413-f7"
+  roles        = [
+    "roles/cloudsql.client",
+  ]
+}

--- a/terraform/serviceAccount.tf
+++ b/terraform/serviceAccount.tf
@@ -5,6 +5,7 @@ module "service_account_chats-service" {
   project_id   = "intricate-pad-455413-f7"
   roles        = [
     "roles/cloudsql.client",
-    "roles/secretmanager.secretAccessor"
+    "roles/secretmanager.secretAccessor",
+    "roles/artifactregistry.reader"
   ]
 }

--- a/terraform/serviceAccount.tf
+++ b/terraform/serviceAccount.tf
@@ -5,5 +5,6 @@ module "service_account_chats-service" {
   project_id   = "intricate-pad-455413-f7"
   roles        = [
     "roles/cloudsql.client",
+    "roles/secretmanager.secretAccessor"
   ]
 }

--- a/terraform/vpcConnector.tf
+++ b/terraform/vpcConnector.tf
@@ -1,0 +1,7 @@
+module "vpc_connector" {
+  source         = "./modules/vpc_connector"
+  name           = "locaccm-vpc-connector"
+  region         = "europe-west1"
+  network        = "locaccm-vpc"
+  ip_cidr_range  = "10.8.0.0/28"
+}


### PR DESCRIPTION
This pull request introduces Terraform configurations and a GitHub Actions workflow to deploy the `chats-service` to Google Cloud Run. The changes include setting up infrastructure modules for Cloud Run, IAM roles, a VPC connector, and defining the deployment pipeline. Below are the key changes grouped by theme:

### Deployment Workflow
* Added a GitHub Actions workflow (`.github/workflows/release.yml`) to automate deployment of the `chats-service` to Google Cloud Run. The workflow includes steps for repository checkout, Google Cloud authentication, and Terraform execution for infrastructure provisioning.

### Cloud Run Configuration
* Created a Terraform module (`terraform/modules/cloud_run`) to define the Cloud Run service, including environment variables, VPC access, and service account configurations. [[1]](diffhunk://#diff-6d87df3c95005ec0e4b23225586c1d52689e8108b6679054a4d26f1d49e94d46R1-R37) [[2]](diffhunk://#diff-182422778eafb35bcae5335bb7eec1d045a3594dd5f638afd3a1ad223414293aR1-R4) [[3]](diffhunk://#diff-5d8eb06ebc1d807a506042f5bd5e916c953ef76907e567ad5988916fa288e538R1-R41)
* Configured the `chats-service` Cloud Run deployment in `terraform/cloudRun.tf`, specifying project details, VPC connector, and invoker permissions.

### IAM and Service Accounts
* Added a Terraform module (`terraform/modules/service_account`) to create and manage service accounts with specific IAM roles. Configured a service account for `chats-service` in `terraform/serviceAccount.tf`. [[1]](diffhunk://#diff-63dff2ccb76df28730ee97ca5bdb5a8b4165a65132328b8a81903d402df59a85R1-R12) [[2]](diffhunk://#diff-771cb31f37e892ecca5925cee55122944d0d01b672f210ccc1542dc74f1637c5R1-R3) [[3]](diffhunk://#diff-80524f73917bda4a33960b1a5752c078511b1df63e4bfe1bdf0fdfbab7e140baR1-R19) [[4]](diffhunk://#diff-83327cb56030cb5c4a2c1f7e7808187e056d54457998476e32767ca9d29319cfR1-R9)

### VPC Connector
* Created a Terraform module (`terraform/modules/vpc_connector`) to define a VPC connector for secure communication. Configured the VPC connector in `terraform/vpcConnector.tf`. [[1]](diffhunk://#diff-54dd0614a7edd52cf6fa456177462b9f28f53f4edf0fe17e8edd0ab0483fc2f2R1-R9) [[2]](diffhunk://#diff-a871265985e6800f14e1c76ec350db1bcf038a35bb86d3dfd4efd1349a4917ffR1-R11) [[3]](diffhunk://#diff-d896744c43298d3c03f3541bf8dd18e5949a52ebc3a14394c50800ad38a866a4R1-R20) [[4]](diffhunk://#diff-447d50f94e7ac9bea958239c1fac9a65d2d238da75105dc20eb10ec9ea528c08R1-R7)

### Terraform Provider Setup
* Added a Google Cloud provider configuration in `terraform/provider.tf` to specify the project, region, and zone for the infrastructure.